### PR TITLE
Timestamps not replaced on pages using Declarative Shadow DOM

### DIFF
--- a/app/src/01_frameworks-driver.layer/contents/contents.ts
+++ b/app/src/01_frameworks-driver.layer/contents/contents.ts
@@ -5,8 +5,10 @@ const theme = document.querySelector("html")?.getAttribute("data-color-mode");
 const useCase = new AbsoluteTimeInteractor();
 
 const observers: MutationObserver[] = [];
-const observeOption = {
+const observeOption: MutationObserverInit = {
   attributes: true,
+  childList: true,
+  subtree: true,
 };
 
 const controller = () => {
@@ -25,6 +27,9 @@ const controller = () => {
     observers.push(observer);
   });
 };
+
+// Initial execution
+controller();
 
 chrome.runtime.onMessage.addListener((_message, _sender, sendResponse) => {
   while (observers.length !== 0) observers.pop()?.disconnect();

--- a/app/src/02_interface-adapter.layer/presenters/Content.presenter.ts
+++ b/app/src/02_interface-adapter.layer/presenters/Content.presenter.ts
@@ -24,8 +24,11 @@ export class ContentPresenter extends OutputPort<ConentOutputData, void> {
   present(output: ConentOutputData): void {
     const { element, theme, page, timestamp, age, timezone } = output;
     // text
-    const dayjsInstance = timezone === "utc" ? dayjs(timestamp).utc() : dayjs(timestamp);
-    element.shadowRoot!.innerHTML = dayjsInstance.format("YYYY-MM-DD HH:mm");
+    const dayjsInstance =
+      timezone === "utc" ? dayjs(timestamp).utc() : dayjs(timestamp);
+    const formatted = dayjsInstance.format("YYYY-MM-DD HH:mm");
+    if (element.shadowRoot) element.shadowRoot.innerHTML = formatted;
+    else element.textContent = formatted;
 
     // color
     const colors =
@@ -71,13 +74,13 @@ export class ContentPresenter extends OutputPort<ConentOutputData, void> {
 
   private getCommitPadding(element: HTMLElement): number {
     return Number(
-      getComputedStyle(element.parentElement!).paddingRight.replace("px", "")
+      getComputedStyle(element.parentElement!).paddingRight.replace("px", ""),
     );
   }
 
   private getBlamePadding(element: HTMLElement): number {
     return Number(
-      getComputedStyle(element.parentElement!).paddingLeft.replace("px", "")
+      getComputedStyle(element.parentElement!).paddingLeft.replace("px", ""),
     );
   }
 
@@ -85,7 +88,8 @@ export class ContentPresenter extends OutputPort<ConentOutputData, void> {
     const canvas = document.createElement("canvas");
     const context = canvas.getContext("2d");
     context!.font = getComputedStyle(element).font;
-    return context!.measureText(element.shadowRoot!.innerHTML).width;
+    const text = element.shadowRoot?.textContent ?? element.textContent ?? "";
+    return context!.measureText(text).width;
   }
 
   private ajustFontSize(element: HTMLElement, padding: number): void {


### PR DESCRIPTION
- Use shadowRoot.innerHTML override to prevent GitHub re-render
- Fallback to element.textContent when shadowRoot is null
- Add childList/subtree to MutationObserver to detect Shadow DOM rebuilds
- Call controller() immediately on content script load
- Fallback to shadowRoot?.textContent in getTextWidth

closes #38