### PR TITLE
Align Options page with Clean Architecture layers

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "enhance-github-timestamps",
   "private": true,
-  "version": "1.2.0",
+  "version": "1.2.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/app/src/01_frameworks-driver.layer/options/Options.view.tsx
+++ b/app/src/01_frameworks-driver.layer/options/Options.view.tsx
@@ -1,0 +1,86 @@
+import { useState, useEffect } from "react";
+import { TimezoneOption } from "../../04_domain.layer/entites/Settings.vo";
+import { GetSettingsInteractor } from "../../03_application.layer/interactors/GetSettings.interactor";
+import { SaveSettingsInteractor } from "../../03_application.layer/interactors/SaveSettings.interactor";
+
+const getSettings = new GetSettingsInteractor();
+const saveSettings = new SaveSettingsInteractor();
+
+export function OptionsView() {
+  const [timezone, setTimezone] = useState<TimezoneOption>("local");
+  const [saved, setSaved] = useState(false);
+
+  useEffect(() => {
+    getSettings.execute().then((result) => {
+      setTimezone(result.timezone);
+    });
+  }, []);
+
+  const handleTimezoneChange = async (tz: TimezoneOption) => {
+    setTimezone(tz);
+    await saveSettings.execute({ timezone: tz });
+    setSaved(true);
+    setTimeout(() => setSaved(false), 2000);
+  };
+
+  return (
+    <div className="max-w-2xl mx-auto p-8">
+      <h1 className="text-3xl font-bold mb-8 text-gray-800">
+        Enhance GitHub Timestamps - Settings
+      </h1>
+      
+      <div className="bg-white rounded-lg shadow-md p-6">
+        <div className="mb-6">
+          <h2 className="text-xl font-semibold mb-4 text-gray-700">
+            Timezone Display
+          </h2>
+          <p className="text-gray-600 mb-4">
+            Choose how timestamps should be displayed on GitHub pages.
+          </p>
+          
+          <div className="space-y-3">
+            <label className="flex items-center">
+              <input
+                type="radio"
+                name="timezone"
+                value="local"
+                checked={timezone === "local"}
+                onChange={() => handleTimezoneChange("local")}
+                className="mr-3"
+              />
+              <div>
+                <span className="font-medium">Local Timezone</span>
+                <p className="text-sm text-gray-500">
+                  Display timestamps in your local timezone
+                </p>
+              </div>
+            </label>
+            
+            <label className="flex items-center">
+              <input
+                type="radio"
+                name="timezone"
+                value="utc"
+                checked={timezone === "utc"}
+                onChange={() => handleTimezoneChange("utc")}
+                className="mr-3"
+              />
+              <div>
+                <span className="font-medium">UTC</span>
+                <p className="text-sm text-gray-500">
+                  Display timestamps in UTC (Coordinated Universal Time)
+                </p>
+              </div>
+            </label>
+          </div>
+        </div>
+        
+        {saved && (
+          <div className="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded">
+            Settings saved successfully!
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/src/03_application.layer/input.data/Settings.id.ts
+++ b/app/src/03_application.layer/input.data/Settings.id.ts
@@ -1,0 +1,5 @@
+import { TimezoneOption } from "../../04_domain.layer/entites/Settings.vo";
+
+export type SaveSettingsInputData = {
+  timezone: TimezoneOption;
+};

--- a/app/src/03_application.layer/interactors/GetSettings.interactor.ts
+++ b/app/src/03_application.layer/interactors/GetSettings.interactor.ts
@@ -1,0 +1,10 @@
+import { InputPort } from "../input.boundary/InputPort";
+import { SettingsService } from "../services/SettingsService";
+import { SettingsOutputData } from "../output.data/Settings.od";
+
+export class GetSettingsInteractor extends InputPort<void, SettingsOutputData> {
+  public async execute(): Promise<SettingsOutputData> {
+    const settings = await SettingsService.getSettings();
+    return { timezone: settings.timezone };
+  }
+}

--- a/app/src/03_application.layer/interactors/SaveSettings.interactor.ts
+++ b/app/src/03_application.layer/interactors/SaveSettings.interactor.ts
@@ -1,0 +1,11 @@
+import { Settings } from "../../04_domain.layer/entites/Settings.vo";
+import { InputPort } from "../input.boundary/InputPort";
+import { SaveSettingsInputData } from "../input.data/Settings.id";
+import { SettingsService } from "../services/SettingsService";
+
+export class SaveSettingsInteractor extends InputPort<SaveSettingsInputData, void> {
+  public async execute(input: SaveSettingsInputData): Promise<void> {
+    const settings = new Settings({ timezone: input.timezone });
+    await SettingsService.saveSettings(settings);
+  }
+}

--- a/app/src/03_application.layer/output.data/Settings.od.ts
+++ b/app/src/03_application.layer/output.data/Settings.od.ts
@@ -1,0 +1,5 @@
+import { TimezoneOption } from "../../04_domain.layer/entites/Settings.vo";
+
+export type SettingsOutputData = {
+  timezone: TimezoneOption;
+};

--- a/app/src/options.tsx
+++ b/app/src/options.tsx
@@ -1,103 +1,10 @@
-import React, { useState, useEffect } from "react";
+import React from "react";
 import ReactDOM from "react-dom/client";
 import "./index.css";
-
-type TimezoneOption = "local" | "utc";
-
-interface Settings {
-  timezone: TimezoneOption;
-}
-
-const defaultSettings: Settings = {
-  timezone: "local",
-};
-
-function Options() {
-  const [settings, setSettings] = useState<Settings>(defaultSettings);
-  const [saved, setSaved] = useState(false);
-
-  useEffect(() => {
-    // Load settings from storage
-    chrome.storage.sync.get(defaultSettings, (result) => {
-      setSettings(result as Settings);
-    });
-  }, []);
-
-  const handleTimezoneChange = (timezone: TimezoneOption) => {
-    const newSettings = { ...settings, timezone };
-    setSettings(newSettings);
-    
-    // Save to storage
-    chrome.storage.sync.set(newSettings, () => {
-      setSaved(true);
-      setTimeout(() => setSaved(false), 2000);
-    });
-  };
-
-  return (
-    <div className="max-w-2xl mx-auto p-8">
-      <h1 className="text-3xl font-bold mb-8 text-gray-800">
-        Enhance GitHub Timestamps - Settings
-      </h1>
-      
-      <div className="bg-white rounded-lg shadow-md p-6">
-        <div className="mb-6">
-          <h2 className="text-xl font-semibold mb-4 text-gray-700">
-            Timezone Display
-          </h2>
-          <p className="text-gray-600 mb-4">
-            Choose how timestamps should be displayed on GitHub pages.
-          </p>
-          
-          <div className="space-y-3">
-            <label className="flex items-center">
-              <input
-                type="radio"
-                name="timezone"
-                value="local"
-                checked={settings.timezone === "local"}
-                onChange={() => handleTimezoneChange("local")}
-                className="mr-3"
-              />
-              <div>
-                <span className="font-medium">Local Timezone</span>
-                <p className="text-sm text-gray-500">
-                  Display timestamps in your local timezone
-                </p>
-              </div>
-            </label>
-            
-            <label className="flex items-center">
-              <input
-                type="radio"
-                name="timezone"
-                value="utc"
-                checked={settings.timezone === "utc"}
-                onChange={() => handleTimezoneChange("utc")}
-                className="mr-3"
-              />
-              <div>
-                <span className="font-medium">UTC</span>
-                <p className="text-sm text-gray-500">
-                  Display timestamps in UTC (Coordinated Universal Time)
-                </p>
-              </div>
-            </label>
-          </div>
-        </div>
-        
-        {saved && (
-          <div className="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded">
-            Settings saved successfully!
-          </div>
-        )}
-      </div>
-    </div>
-  );
-}
+import { OptionsView } from "./01_frameworks-driver.layer/options/Options.view";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <Options />
+    <OptionsView />
   </React.StrictMode>
 );


### PR DESCRIPTION
- Extract view to 01_frameworks-driver.layer/options/Options.view.tsx
- Keep options.tsx as entry point only (ReactDOM mount)
- Add GetSettings/SaveSettings interactors in Application layer
- Add Settings.id.ts and Settings.od.ts for input/output data
- Bump version to 1.2.1

Closes #40